### PR TITLE
Ensure absolute path in example decorator for backwards compatibility

### DIFF
--- a/examples/common/example.py
+++ b/examples/common/example.py
@@ -129,7 +129,10 @@ def caracara_example(example_func):
 
         client = Client(**falcon_config)
 
-        example_settings = _get_example_settings(profile, example_func.__globals__['__file__'])
+        example_settings = _get_example_settings(
+            profile,
+            example_func.__globals__['__file__'],
+        )
 
         # Pass data back to the example via keyword arguments
         kwargs['client'] = client


### PR DESCRIPTION
# Pull Request Title

- [ ] Enhancement
- [ ] Major feature update
- [x] Bug fixes
- [ ] Breaking change
- [ ] Updated unit tests
- [ ] Documentation

## Bandit analysis

```shell
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.8.9
Run started:2022-06-28 17:30:44.804913

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 0
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
        Total issues (by confidence):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
Files skipped (1):
        ... (No such file or directory)
```

## Added features and functionality

N/A

## Issues resolved

- Running `examples/get_devices/list_windows_devices.py` in Python 3.8 will error with `ValueError: Can't mix absolute and relative paths`. This is because pre-3.9 the `__file__` global is relative, whereas 3.9+ it is absolute (ctrl+f for `__file__` [here](l)). This PR fixes this and maintains backwards compatibility


## Other

- [Python 3.9 Release notes](https://docs.python.org/3/whatsnew/3.9.html) (ctrl+f for `__file__` to see this change)
