### PR TITLE
Add GitHub actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Updates dependabot to check GH actions for dependency updates.