### PR TITLE
Added temporary workaround for storing `ioa_rule_groups` in `Policy`

### DIFF
--- a/caracara/common/policy_wrapper.py
+++ b/caracara/common/policy_wrapper.py
@@ -9,7 +9,7 @@ It is to be extended by the respective modules (response_policies, prevention_po
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Dict, List
+from typing import Any, Dict, List
 
 
 class PolicySetting(ABC):
@@ -285,7 +285,7 @@ class Policy:
 
     # TODO: Replace with a proper wrapper around ioa_rule_groups, this is temporary so that this
     #       result is still reachable from the 'dump' method when style="prevention".
-    _raw_ioa_rule_groups: dict = None
+    _raw_ioa_rule_groups: List[Dict[str, Any]] = None
 
     def __init__(self, data_dict: Dict = None, style: str = "response"):
         """

--- a/caracara/common/policy_wrapper.py
+++ b/caracara/common/policy_wrapper.py
@@ -325,7 +325,7 @@ class Policy:
         self.modified_timestamp = data_dict.get("modified_timestamp")
         self.name = data_dict.get("name")
         self.platform_name = data_dict.get("platform_name")
-        self._raw_ioa_rule_groups = data_dict.get("ioa_rule_groups") # TODO: see earlier TODO
+        self._raw_ioa_rule_groups = data_dict.get("ioa_rule_groups")  # TODO: see earlier TODO
 
         # Load all groups as GroupAssignment objects
         groups: List[Dict] = data_dict.get("groups", [])
@@ -362,7 +362,7 @@ class Policy:
         }
 
         if self.style == "prevention":
-            dumped["ioa_rule_groups"] = self._raw_ioa_rule_groups # TODO: see earlier TODO
+            dumped["ioa_rule_groups"] = self._raw_ioa_rule_groups  # TODO: see earlier TODO
 
         return dumped
 

--- a/caracara/common/policy_wrapper.py
+++ b/caracara/common/policy_wrapper.py
@@ -281,6 +281,10 @@ class Policy:
     settings_groups: List[PolicySettingGroup] = None
     settings_key_name = "settings"
 
+    # TODO: Replace with a proper wrapper around ioa_rule_groups, this is temporary so that this
+    #       result is still reachable from the 'dump' method when style="prevention".
+    _raw_ioa_rule_groups: dict = None
+
     def __init__(self, data_dict: Dict = None, style: str = "response"):
         """
         Return a completely built Policy object.
@@ -319,6 +323,7 @@ class Policy:
         self.modified_timestamp = data_dict.get("modified_timestamp")
         self.name = data_dict.get("name")
         self.platform_name = data_dict.get("platform_name")
+        self._raw_ioa_rule_groups = data_dict.get("ioa_rule_groups") # TODO: see earlier TODO
 
         # Load all groups as GroupAssignment objects
         groups: List[Dict] = data_dict.get("groups", [])
@@ -338,7 +343,7 @@ class Policy:
         can replicate the exact response sent back by the CrowdStrike API if this policy
         already happened to exist in the Cloud.
         """
-        return {
+        dumped = {
             "cid": self.cid,
             "created_by": self.created_by,
             "created_timestamp": self.created_timestamp,
@@ -350,8 +355,14 @@ class Policy:
             "modified_timestamp": self.modified_timestamp,
             "name": self.name,
             "platform_name": self.platform_name,
+            "ioa_rule_groups": self._raw_ioa_rule_groups,
             self.settings_key_name: [x.dump() for x in self.settings_groups],
         }
+
+        if self.style == "prevention":
+            dumped["ioa_rule_groups"] = self._raw_ioa_rule_groups # TODO: see earlier TODO
+
+        return dumped
 
     def flat_dump(self) -> Dict:
         """

--- a/caracara/common/policy_wrapper.py
+++ b/caracara/common/policy_wrapper.py
@@ -1,3 +1,5 @@
+# Disable TODO warning, to be removed when a wrapper is implemented for `ioa_rule_groups`
+# pylint: disable=W0511
 """
 Caracara wrapper for Policies API.
 


### PR DESCRIPTION
# Temporary workaround for `ioa_rule_groups` in `Policy`

- [ ] Enhancement
- [ ] Major feature update
- [x] Bug fixes
- [ ] Breaking change
- [ ] Updated unit tests
- [ ] Documentation

## Bandit analysis

```shell
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.10.5
Run started:2022-07-20 15:33:51.235798

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 0
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
        Total issues (by confidence):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
```

## Issues resolved

- `Policy.dump` claims that it conforms to the CrowdStrike API Spec, but it in the case where `style="prevention"`, it does not conform as doesn't as it doesn't have an `ioa_rule_groups` key. In the future I assume we'll have a proper wrapper for `ioa_rule_groups`, but as a temporary work around to keep `dump`'s claims true this should work. I've also added TODOs so hopefully this won't be forgotten when it comes to implementing that wrapper.

## Other

- I encountered this whilst working on tests in #30