### PR TITLE
Expose RTRBatchSession via __init__.py

### DIFF
--- a/caracara/modules/rtr/__init__.py
+++ b/caracara/modules/rtr/__init__.py
@@ -3,12 +3,14 @@ __all__ = [
     'BatchGetCmdRequest',
     'FILTER_ATTRIBUTES',
     'GetFile',
+    'InnerRTRBatchSession',
     'RTRApiModule',
     'RTRBatchSession',
 ]
 
 from caracara.modules.rtr.batch_session import (
     BatchGetCmdRequest,
+    InnerRTRBatchSession,
     RTRBatchSession,
 )
 from caracara.modules.rtr.get_file import GetFile

--- a/caracara/modules/rtr/__init__.py
+++ b/caracara/modules/rtr/__init__.py
@@ -4,9 +4,13 @@ __all__ = [
     'FILTER_ATTRIBUTES',
     'GetFile',
     'RTRApiModule',
+    'RTRBatchSession',
 ]
 
-from caracara.modules.rtr.batch_session import BatchGetCmdRequest
+from caracara.modules.rtr.batch_session import (
+    BatchGetCmdRequest,
+    RTRBatchSession,
+)
 from caracara.modules.rtr.get_file import GetFile
 from caracara.modules.rtr.rtr import RTRApiModule
 from caracara.modules.rtr.rtr_filters import FILTER_ATTRIBUTES


### PR DESCRIPTION
# Make the RTRBatchSession class externally accessible

Quite simply: we need to be able to access this class for type hinting and integrations. Right now we can't. With this PR, we should be able to 🤞 

This is a very minor fix