### PR TITLE
Fix typo that causes filters to not work in `PreventionPoliciesApiModule`

### DIFF
--- a/caracara/modules/prevention_policies/prevention_policies.py
+++ b/caracara/modules/prevention_policies/prevention_policies.py
@@ -44,7 +44,7 @@ class PreventionPoliciesApiModule(FalconApiModule):
         self.logger.info("Describing all Falcon prevention policies")
         partial_func = partial(
             self.prevention_policies_api.query_combined_policies,
-            filters=filters,
+            filter=filters,
             sort=sort,
         )
         resources = all_pages_numbered_offset_parallel(func=partial_func, logger=self.logger)


### PR DESCRIPTION
# Fix typo that causes filters to not work in `PreventionPoliciesApiModule`


- [ ] Enhancement
- [ ] Major feature update
- [x] Bug fixes
- [ ] Breaking change
- [ ] Updated unit tests
- [ ] Documentation

## Bandit analysis

```shell
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.10.5
Run started:2022-08-05 17:01:08.659167

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 0
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
        Total issues (by confidence):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
```

## Issues resolved

- Bug fix: When calling `query_combined_policies` in `PreventionPoliciesApiModule.describe_policies_raw`, the provided `filters` kwarg is passed as `filters`, when the API actually expects it as `filter`. See below for test script.

## Other

Script that shows bug:
```py
from caracara import Client
from caracara.filters import FalconFilter
import os

client = Client(
    client_id=os.getenv("FALCON_CLIENT_ID"),
    client_secret=os.getenv("FALCON_CLIENT_SECRET"),
)

filters = client.FalconFilter()
filters.create_new_filter("OS", "Windows")

res1 = client.prevention_policies.describe_policies_raw(filters=filters)
res2 = client.response_policies.describe_policies_raw(filters=filters)

oses1 = {x["platform_name"] for x in res1}
oses2 = {x["platform_name"] for x in res2}

print(f"Prevention policy (should just be Windows): {oses1}")
print(f"Response policy (should just be Windows): {oses2}")
```

When run without this fix:
```sh
$ python3 test.py
Prevention policy (should just be Windows): {'Linux', 'iOS', 'Windows', 'Android', 'Mac'}
Response policy (should just be Windows): {'Windows'}
```

When run with this fix:
```sh
$ python3 test.py                          
Prevention policy (should just be Windows): {'Windows'}
Response policy (should just be Windows): {'Windows'}
```

Found whilst working on #30 