### PR TITLE
Fix bug that `ioa_rule_groups` is dumped with response policies

### DIFF
--- a/caracara/common/policy_wrapper.py
+++ b/caracara/common/policy_wrapper.py
@@ -382,7 +382,6 @@ class Policy:
             "modified_timestamp": self.modified_timestamp,
             "name": self.name,
             "platform_name": self.platform_name,
-            "ioa_rule_groups": self._raw_ioa_rule_groups,
             self.settings_key_name: [x.dump() for x in self.settings_groups],
         }
 


### PR DESCRIPTION
# Fix bug that `ioa_rule_groups` is dumped with response policies

- [x] Bug fixes

## Issues resolved

- Bug fix: In an earlier PR #32 I added a temporary workaround so `ioa_rule_groups` is still accessible through the `Policy` wrapper, but I accidentally also introduced a bug that dumped this with response policies, when it should only be for prevention policies. This is a quick PR to fix that.