### PR TITLE
Adds Online/Offline Host Filtering

### DIFF
--- a/caracara/modules/hosts/hosts_filters.py
+++ b/caracara/modules/hosts/hosts_filters.py
@@ -22,6 +22,27 @@ class HostContainedFilterAttribute(FalconFilterAttribute):
     restrict = True
 
 
+class HostConnectionStatusFilterAttribute(FalconFilterAttribute):
+    """
+    Filter by whether a host is connected to the Falcon cloud.
+
+    Current valid options are Online and Offline.
+    """
+
+    name = "ConnectionStatus"
+    fql = "connection_status"
+    options = ["Online", "Offline"]
+    restrict = True
+
+    def example(self) -> str:
+        """Show filter example."""
+        return (
+            "This filter allows you to search for systems based on whether Falcon assesses them "
+            "as being Online or Offline. Theoretically, all 'Online' systems should be available "
+            "to connect to via Real Time Response (RTR)."
+        )
+
+
 class HostDomainFqlFilterAttribute(FalconFilterAttribute):
     """Filter by host AD domain."""
 
@@ -271,6 +292,7 @@ class HostOUFilterAttribute(FalconFilterAttribute):
 
 FILTER_ATTRIBUTES = [
     HostContainedFilterAttribute,
+    HostConnectionStatusFilterAttribute,
     HostDomainFqlFilterAttribute,
     HostGroupIdFilterAttribute,
     HostHostnameFilterAttribute,


### PR DESCRIPTION
# Host Connection Status Filter

Adds filtering logic to search for only Online or Offline hosts. This avoids the need to use a filter like `LastSeen` to determine which hosts are switched on.

- [X] Enhancement
- [ ] Major feature update
- [ ] Bug fixes
- [ ] Breaking change
- [ ] Updated unit tests
- [ ] Documentation