### PR TITLE
[FEATURE] Add ability to filter on host online state

### DIFF
--- a/caracara/common/constants.py
+++ b/caracara/common/constants.py
@@ -1,4 +1,5 @@
 """Common constants to be shared throughout Caracara."""
+from enum import Enum, EnumMeta
 
 FILTER_OPERATORS = {
     "EQUAL": '',
@@ -30,3 +31,33 @@ PLATFORMS = [
 
 #
 DEFAULT_COMMENT = "This action was performed by the Caracara Python library."
+
+
+# Device online states classes
+class MetaEnum(EnumMeta):
+    """Overrided class for the use of the in operator and to query for all valid enum values."""
+
+    def __init__(cls, *kwargs):
+        """Store all possible values of the Enum subclass."""
+        cls.VALUES = [state.value for state in cls.__members__.values()]
+        super().__init__(kwargs)
+
+    def __contains__(cls: Enum, item: str) -> bool:
+        """Override the __contains__ method to use the in operator with Enum subclasses."""
+        return item in cls.VALUES
+
+
+class OnlineState(Enum, metaclass=MetaEnum):
+    """
+    Falcon OnlineState class.
+
+    Enum class of valid device online states. Valid states are 'online', 'offline', and 'unknown'.
+    """
+
+    ONLINE = "online"
+    OFFLINE = "offline"
+    UNKNOWN = "unknown"
+
+    def __eq__(self, item: str) -> bool:
+        """Override the __eq__ method for strings to compare the OnlineState's string value."""
+        return str(self.value) == item

--- a/caracara/common/exceptions.py
+++ b/caracara/common/exceptions.py
@@ -1,5 +1,6 @@
 """Caracara exceptions."""
 from typing import Dict, List
+
 from caracara.common.constants import OnlineState
 
 

--- a/caracara/common/exceptions.py
+++ b/caracara/common/exceptions.py
@@ -1,5 +1,6 @@
 """Caracara exceptions."""
 from typing import Dict, List
+from caracara.common.constants import OnlineState
 
 
 class BaseCaracaraError(Exception):
@@ -112,5 +113,18 @@ class MissingArguments(GenericAPIError):
         self.errors = [{
             "code": 500,
             "message": arg_str
+        }]
+        super().__init__(self.errors)
+
+
+class InvalidOnlineState(GenericAPIError):
+    """The provided online state is invalid."""
+
+    def __init__(self, online_state_string):
+        """Construct an instance of the InvalidOnlineState class."""
+        self.errors = [{
+            "code": 500,
+            "message": f"Invalid online state '{online_state_string}'. \
+                        Expected one of {OnlineState.VALUES}."
         }]
         super().__init__(self.errors)

--- a/caracara/modules/hosts/_data_history.py
+++ b/caracara/modules/hosts/_data_history.py
@@ -71,7 +71,6 @@ def describe_state(
     """Return a dictionary containing online state for devices matching the provided filter.
 
     DEPRECATED. The describe_devices function now captures this functionality.
-    """
 
     Arguments
     ---------

--- a/caracara/modules/hosts/_data_history.py
+++ b/caracara/modules/hosts/_data_history.py
@@ -68,6 +68,7 @@ def describe_state(
     self: HostsApiModule,
     filters: FalconFilter or str = None,
 ) -> Dict[str, Dict]:
+    """NOTE: DEPRECATED. The describe_devices function now captures this functionality."""
     """Return a dictionary containing online state for devices matching the provided filter.
 
     Arguments

--- a/caracara/modules/hosts/_data_history.py
+++ b/caracara/modules/hosts/_data_history.py
@@ -68,8 +68,10 @@ def describe_state(
     self: HostsApiModule,
     filters: FalconFilter or str = None,
 ) -> Dict[str, Dict]:
-    """NOTE: DEPRECATED. The describe_devices function now captures this functionality."""
     """Return a dictionary containing online state for devices matching the provided filter.
+
+    DEPRECATED. The describe_devices function now captures this functionality.
+    """
 
     Arguments
     ---------

--- a/caracara/modules/hosts/_online_state.py
+++ b/caracara/modules/hosts/_online_state.py
@@ -1,0 +1,46 @@
+"""Caracara Hosts Module: host online state functions.
+
+In order to avoid the main hosts.py file getting too unwieldly, this file contains
+the implementations of the host online state query functions.
+"""
+# Disable the protected access rule because this file is an extension of the class in hosts.py.
+# pylint: disable=protected-access
+from __future__ import annotations
+from typing import (
+    List,
+    TYPE_CHECKING,
+)
+
+if TYPE_CHECKING:
+    from caracara.modules.hosts import HostsApiModule
+
+
+def filter_by_online_state(
+    self: HostsApiModule,
+    device_ids: List[str],
+    online_state: bool,
+):
+    """Filter a list of device IDs by an online state.
+    
+        Arguments
+        ---------
+        device_ids: List[str]
+            Device IDs to filter against
+        online_state: bool
+            Online state to filter device IDs on
+
+        Returns
+        -------
+        List[str]: A list of device IDs with the specified online state
+    """
+    device_online_state_data = self.get_online_state(device_ids)
+
+    filtered_device_ids = []
+    for device_id, device_data in device_online_state_data.items():
+        if device_data['state'] == "online" and online_state:
+            filtered_device_ids.append(device_id)
+        elif device_data['state'] != "online" and not online_state:
+            # Consider offline and unknown states to be equivalent
+            filtered_device_ids.append(device_id)
+    
+    return filtered_device_ids 

--- a/caracara/modules/hosts/_online_state.py
+++ b/caracara/modules/hosts/_online_state.py
@@ -11,36 +11,78 @@ from typing import (
     TYPE_CHECKING,
 )
 
+from caracara.common.batching import batch_get_data
+from caracara.common.constants import OnlineState
+from caracara.common.exceptions import InvalidOnlineState
+
 if TYPE_CHECKING:
     from caracara.modules.hosts import HostsApiModule
 
 
-def filter_by_online_state(
+def validate_online_state(
+        self: HostsApiModule,
+        online_state: OnlineState or str,
+):
+    """Raise an exception if the online_state_string is not a valid online state.
+
+    Arguments
+    ---------
+    online_state: OnlineState or str, required
+        OnlineState or string to validate.
+    """
+    if not isinstance(online_state, OnlineState) and online_state not in OnlineState:
+        raise InvalidOnlineState(online_state)
+    self.logger.debug(f"Validated online state {online_state}")
+
+
+def get_online_state(
+        self: HostsApiModule,
+        device_ids: List[str],
+) -> List[str]:
+    """Return a dictionary containing online state details for every device specified by ID.
+
+    You should only use this endpoint if you already have a list of Device IDs / AIDs,
+    and want to retreive data about them directly. If you need to get device data via a
+    filter, and you do not yet have a list of Device IDs, you should consider using the
+    describe_devices() function.
+
+    Arguments
+    ---------
+    device_ids: [str], required
+        A list of Falcon Device IDs.
+
+    Returns
+    -------
+    dict: A dictionary containing online state details for every device listed.
+    """
+    self.logger.info("Obtaining online state data for %s devices", len(device_ids))
+    device_online_state_data = batch_get_data(device_ids, self.hosts_api.get_online_state)
+    return device_online_state_data
+
+
+def filter_device_ids_by_online_state(
     self: HostsApiModule,
     device_ids: List[str],
-    online_state: bool,
-):
+    online_state: OnlineState or str,
+) -> List[str]:
     """Filter a list of device IDs by an online state.
 
-        Arguments
-        ---------
-        device_ids: List[str]
-            Device IDs to filter against
-        online_state: bool
-            Online state to filter device IDs on
+    Arguments
+    ---------
+    device_ids: List[str]
+        Device IDs to filter against
+    online_state: OnlineState or str
+        Online state to filter device IDs on. Options are "online", "offline", "unknown"
 
-        Returns
-        -------
-        List[str]: A list of device IDs with the specified online state
+    Returns
+    -------
+    List[str]: A list of device IDs with the specified online state
     """
-    device_online_state_data = self.get_online_state(device_ids)
+    self.validate_online_state(online_state)
 
-    filtered_device_ids = []
-    for device_id, device_data in device_online_state_data.items():
-        if device_data['state'] == "online" and online_state:
-            filtered_device_ids.append(device_id)
-        elif device_data['state'] != "online" and not online_state:
-            # Consider offline and unknown states to be equivalent
-            filtered_device_ids.append(device_id)
+    device_state_data = self.get_online_state(device_ids)
 
-    return filtered_device_ids
+    return list(filter(
+        lambda device_id: device_state_data[device_id]["state"] == online_state,
+        device_state_data,
+    ))

--- a/caracara/modules/hosts/_online_state.py
+++ b/caracara/modules/hosts/_online_state.py
@@ -21,7 +21,7 @@ def filter_by_online_state(
     online_state: bool,
 ):
     """Filter a list of device IDs by an online state.
-    
+
         Arguments
         ---------
         device_ids: List[str]
@@ -42,5 +42,5 @@ def filter_by_online_state(
         elif device_data['state'] != "online" and not online_state:
             # Consider offline and unknown states to be equivalent
             filtered_device_ids.append(device_id)
-    
-    return filtered_device_ids 
+
+    return filtered_device_ids

--- a/caracara/modules/hosts/hosts.py
+++ b/caracara/modules/hosts/hosts.py
@@ -14,6 +14,8 @@ from functools import partial
 from typing import (
     Dict,
     List,
+    Union,
+    Optional,
 )
 
 from falconpy import (
@@ -129,7 +131,7 @@ class HostsApiModule(FalconApiModule):
     def describe_devices(
         self,
         filters: FalconFilter or str = None,
-        online_state: OnlineState or str = None,
+        online_state: Optional[Union[OnlineState, str]] = None,
     ) -> Dict[str, Dict]:
         """Return a dictionary containing details for every device matching the provided filter.
 
@@ -194,7 +196,7 @@ class HostsApiModule(FalconApiModule):
     def get_device_ids(
         self,
         filters: FalconFilter or str = None,
-        online_state: OnlineState or str = None,
+        online_state: Optional[Union[OnlineState, str]] = None,
     ) -> List[str]:
         """Return a list of IDs (string) for every device in your Falcon tenant.
 

--- a/caracara/modules/hosts/hosts.py
+++ b/caracara/modules/hosts/hosts.py
@@ -191,7 +191,7 @@ class HostsApiModule(FalconApiModule):
             id_list = self.filter_by_online_state(id_list, online_state=online_state)
 
         return id_list
-    
+
     def get_online_state(self, device_ids: List[str]) -> List[str]:
         """Return a dictionary containing online state details for every device specified by ID.
 

--- a/caracara/modules/hosts/hosts.py
+++ b/caracara/modules/hosts/hosts.py
@@ -139,7 +139,7 @@ class HostsApiModule(FalconApiModule):
         # Filter by online state, if applicable
         if online_state is not None:
             self.logger.info("Checking the online state of the device IDs")
-            id_list = self.filter_by_online_state(id_list, online_state=online_state)
+            device_ids = self.filter_by_online_state(device_ids, online_state=online_state)
 
         device_data = self.get_device_data(device_ids)
 

--- a/caracara/modules/hosts/hosts.py
+++ b/caracara/modules/hosts/hosts.py
@@ -170,3 +170,24 @@ class HostsApiModule(FalconApiModule):
         func = partial(self.hosts_api.query_devices_by_filter_scroll, filter=filters)
         id_list: List[str] = all_pages_token_offset(func=func, logger=self.logger)
         return id_list
+    
+    def get_online_state(self, device_ids: List[str]) -> List[str]:
+        """Return a dictionary containing online state details for every device specified by ID.
+
+        You should only use this endpoint if you already have a list of Device IDs / AIDs,
+        and want to retreive data about them directly. If you need to get device data via a
+        filter, and you do not yet have a list of Device IDs, you should consider using the
+        describe_devices() function.
+
+        Arguments
+        ---------
+        device_ids: [str], required
+            A list of Falcon Device IDs.
+
+        Returns
+        -------
+        dict: A dictionary containing online state details for every device listed.
+        """
+        self.logger.info("Obtaining online state data for %s devices", len(device_ids))
+        device_online_state_data = batch_get_data(device_ids, self.hosts_api.get_online_state)
+        return device_online_state_data

--- a/caracara/modules/hosts/hosts_filters.py
+++ b/caracara/modules/hosts/hosts_filters.py
@@ -271,7 +271,6 @@ class HostOUFilterAttribute(FalconFilterAttribute):
 
 FILTER_ATTRIBUTES = [
     HostContainedFilterAttribute,
-    HostConnectionStatusFilterAttribute,
     HostDomainFqlFilterAttribute,
     HostGroupIdFilterAttribute,
     HostHostnameFilterAttribute,

--- a/caracara/modules/hosts/hosts_filters.py
+++ b/caracara/modules/hosts/hosts_filters.py
@@ -22,27 +22,6 @@ class HostContainedFilterAttribute(FalconFilterAttribute):
     restrict = True
 
 
-class HostConnectionStatusFilterAttribute(FalconFilterAttribute):
-    """
-    Filter by whether a host is connected to the Falcon cloud.
-
-    Current valid options are Online and Offline.
-    """
-
-    name = "ConnectionStatus"
-    fql = "connection_status"
-    options = ["Online", "Offline"]
-    restrict = True
-
-    def example(self) -> str:
-        """Show filter example."""
-        return (
-            "This filter allows you to search for systems based on whether Falcon assesses them "
-            "as being Online or Offline. Theoretically, all 'Online' systems should be available "
-            "to connect to via Real Time Response (RTR)."
-        )
-
-
 class HostDomainFqlFilterAttribute(FalconFilterAttribute):
     """Filter by host AD domain."""
 


### PR DESCRIPTION
# Adds Filtering on Host Online State

- [x] Enhancement
- [x] Major feature update
- [ ] Bug fixes
- [ ] Breaking change
- [x] Updated unit tests
- [x] Documentation

## Bandit analysis

```shell
Run started:2023-05-04 20:00:15.160487

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 5694
        Total lines skipped (#nosec): 1

Run metrics:
        Total issues (by severity):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
        Total issues (by confidence):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
Files skipped (0):
```

## Added features and functionality

This PR adds a hook to the Falcon API  hosts endpoint `get_online_state` and functionality around this endpoint, including filtering host searches by online state and enriching describe device queries with online state data.

## Issues resolved

- Progress towards resolving the Falcon-Toolkit issue [Suggestion - add a command that reports the connected hosts.](https://github.com/CrowdStrike/Falcon-Toolkit/issues/42)

## Other

- Added `caracara.modules.hosts.get_online_state` to retrieve the online state for a list of Falcon Device IDs.
- The existing method `caracara.modules.hosts.describe_devices` now enriches the data with the online state. Note: this deprecates the method `caracara.modules.hosts._data_history.describe_state`. I left this method in for the time being for backwards compatibility.
- The `caracara.modules.hosts` methods `describe_devices` and `get_device_ids` now support optional filtering by the online states `online`, `offline`, and `unknown`. The argument is optional and this is not a breaking change for dependent projects such as `Falcon-Toolkit`.
- Removed the Falcon Filter Attribute `HostConnectionStatusFilterAttribute`, since the Falcon API does not support FQL filtering on connection status and this PR implements what it was trying to do.