### PR TITLE
[BUGFIX] Remove online state enrichment in describe_devices() by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "caracara"
-version = "0.3.0"
+version = "0.3.1"
 description = "The CrowdStrike Falcon Developer Toolkit"
 authors = [ "CrowdStrike <falconpy@crowdstrike.com>" ]
 readme = "README.md"

--- a/tests/unit_tests/test_hosts.py
+++ b/tests/unit_tests/test_hosts.py
@@ -151,8 +151,7 @@ def test_describe_devices(auth: Client, **_):
     visible_devices = dict(
         (id_, dev) for id_, dev in mock_devices.items() if dev.get("host_hidden_status") != "hidden"
     )
-    for device_id, data in visible_devices.items():
-        data["state"] = mock_device_online_states[device_id]["state"]
+
     assert auth.hosts.describe_devices() == visible_devices
 
 
@@ -170,8 +169,6 @@ def test_describe_devices__online_only(auth: Client, **_):
         lambda item: item[0] in list(set(visible_ids) & set(online_ids)),
         mock_devices.items(),
     ))
-    for _, dev in online_visible_devices.items():
-        dev["state"] = "online"
 
     assert auth.hosts.describe_devices(online_state="online") == online_visible_devices
 
@@ -190,8 +187,7 @@ def test_describe_devices__enum_online_state(auth: Client, **_):
         lambda item: item[0] in list(set(visible_ids) & set(offline_ids)),
         mock_devices.items(),
     ))
-    for _, dev in offline_visible_devices.items():
-        dev["state"] = "offline"
+
     assert auth.hosts.describe_devices(online_state=OnlineState.OFFLINE) == offline_visible_devices
 
 


### PR DESCRIPTION
# Skip online state enrichment in describe_devices() by default

- [ ] Enhancement
- [ ] Major feature update
- [x] Bug fixes
- [ ] Breaking change
- [ ] Updated unit tests
- [ ] Documentation

## Bandit analysis

```shell
Run started:2023-05-25 13:39:24.885780

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 5937
        Total lines skipped (#nosec): 1

Run metrics:
        Total issues (by severity):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
        Total issues (by confidence):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
Files skipped (0):
```

## Issues resolved

- Bug fix: #99 

## Other

- describe_devices() has a new optional parameter that defaults to `False` to specify if you want to enrich the results with the online state of the device. More testing is needed for large environments before setting that parameter to `True`.
