### PR TITLE
Sets the batch size for RTR PUT files to 100

### DIFF
--- a/caracara/modules/rtr/rtr.py
+++ b/caracara/modules/rtr/rtr.py
@@ -170,7 +170,11 @@ class RTRApiModule(FalconApiModule):
         self.logger.info("Retreived %d PUT file IDs", len(put_file_ids))
         self.logger.debug(put_file_ids)
 
-        put_file_data = batch_get_data(put_file_ids, self.rtr_admin_api.get_put_files)
+        put_file_data = batch_get_data(
+            put_file_ids,
+            self.rtr_admin_api.get_put_files,
+            data_batch_size=100,
+        )
         return put_file_data
 
     def create_put_file(self, file_path: str, name: str = None, description: str = None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "caracara"
-version = "0.5.2"
+version = "0.5.3"
 description = "The CrowdStrike Falcon Developer Toolkit"
 authors = [ "CrowdStrike <falconpy@crowdstrike.com>" ]
 readme = "README.md"


### PR DESCRIPTION
# RTR PUT Files Batch Limit Fix

This PR introduces a fix that should allow https://github.com/CrowdStrike/Falcon-Toolkit/issues/104 to be fixed in the next build of Falcon Toolkit.