### PR TITLE
Update unit tests' mock auth objects to use auto-speccing

### DIFF
--- a/tests/unit_tests/test_custom_ioas.py
+++ b/tests/unit_tests/test_custom_ioas.py
@@ -25,7 +25,7 @@ def client():
     """Pytest fixture that provides a client with a mocked OAuth2 object, so no API credentials
     are needed.
     """
-    auth = MagicMock(autospec=falconpy.OAuth2)
+    auth = MagicMock(spec=falconpy.OAuth2, autospec=True)
     client = Client(falconpy_authobject=auth)
     return client
 

--- a/tests/unit_tests/test_hosts.py
+++ b/tests/unit_tests/test_hosts.py
@@ -115,7 +115,7 @@ def hosts_test():
     def decorator(func):
         @patch("caracara.modules.hosts.hosts.HostGroup", autospec=falconpy.HostGroup)
         @patch("caracara.modules.hosts.hosts.Hosts", autospec=falconpy.Hosts)
-        @patch("caracara.client.OAuth2")
+        @patch("caracara.client.OAuth2", autospec=True)
         def new_func(mock_oauth2, mock_hosts, mock_hostgroup):
             # B106 is a bandit warning for hardcoded passwords.
             # This is a testing context and the credentials passed to this constructor

--- a/tests/unit_tests/test_prevention_policies.py
+++ b/tests/unit_tests/test_prevention_policies.py
@@ -17,7 +17,7 @@ def prevpol_test():
             "caracara.modules.prevention_policies.prevention_policies.PreventionPolicies",
             autospec=falconpy.PreventionPolicies,
         )
-        @patch("caracara.client.OAuth2")
+        @patch("caracara.client.OAuth2", autospec=True)
         def test_new_func(mock_oauth2, mock_prevpol):
             # B106 is a bandit warning for hardcoded passwords.
             # This is a testing context and the credentials passed to this constructor

--- a/tests/unit_tests/test_response_policies.py
+++ b/tests/unit_tests/test_response_policies.py
@@ -17,7 +17,7 @@ def respol_test():
             "caracara.modules.response_policies.response_policies.ResponsePolicies",
             autospec=falconpy.ResponsePolicies,
         )
-        @patch("caracara.client.OAuth2")
+        @patch("caracara.client.OAuth2", autospec=True)
         def test_new_func(mock_oauth2, mock_prevpol):
             # B106 is a bandit warning for hardcoded passwords, this is a testing context and
             # the credentials passed to this constructor aren't valid and aren't used.


### PR DESCRIPTION
# Update unit tests' mock auth objects to use auto-speccing

- [ ] Enhancement
- [ ] Major feature update
- [X] Bug fixes
- [ ] Breaking change
- [ ] Updated unit tests
- [ ] Documentation

> Check the values above that match your PR and remove the remaining.

## Bandit analysis

```shell
(caracara-py3.11) USER-REDACTED@HOSTNAME-REDACTED tests % bandit -r . --configfile=.bandit
[main]	INFO	Found project level .bandit file: ./.bandit
[utils]	WARNING	Unable to parse config file ./.bandit or missing [bandit] section
[main]	INFO	profile include tests: None
[main]	INFO	profile exclude tests: B101
[main]	INFO	cli include tests: None
[main]	INFO	cli exclude tests: None
[main]	INFO	using config: .bandit
[main]	INFO	running on Python 3.11.9
Run started:2024-10-17 14:55:08.937788

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 1445
	Total lines skipped (#nosec): 0

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
Files skipped (0):
```

## Added features and functionality

Fixed an issue with executing unit tests

## Issues resolved

- Fixes #214 by configuring auto-speccing for unit tests

## Other

