### PR TITLE
Fixes handling of Custom IOA Rule Group Versioning

### DIFF
--- a/caracara/modules/custom_ioa/custom_ioa.py
+++ b/caracara/modules/custom_ioa/custom_ioa.py
@@ -208,11 +208,12 @@ class CustomIoaApiModule(FalconApiModule):
             new_rules.append(new_rule)
             new_group.version += 1
 
-        new_group.rules = list(chain((
-            rule for rule in group.rules if rule.exists_in_cloud()),
-            (new_rule for rule in new_rules))
+        new_group.rules = list(
+            chain(
+                (rule for rule in group.rules if rule.exists_in_cloud()),
+                (new_rule for rule in new_rules),
+            )
         )
-
 
         # Delete rules queued for deletion, if any
         if len(group.rules_to_delete) > 0:

--- a/caracara/modules/custom_ioa/custom_ioa.py
+++ b/caracara/modules/custom_ioa/custom_ioa.py
@@ -209,7 +209,7 @@ class CustomIoaApiModule(FalconApiModule):
             new_group.version += 1
 
         new_group.rules = list(chain((
-            rule for rule in group.rules if rule.exists_in_cloud()), 
+            rule for rule in group.rules if rule.exists_in_cloud()),
             (new_rule for rule in new_rules))
         )
 

--- a/caracara/modules/custom_ioa/custom_ioa.py
+++ b/caracara/modules/custom_ioa/custom_ioa.py
@@ -216,8 +216,8 @@ class CustomIoaApiModule(FalconApiModule):
             )
             # If successful (i.e. no exceptions raised), clear the deletion queue
             group.rules_to_delete = []
-        
-        new_group.version += len(new_group.rules) + bool(group.rules_to_delete)
+
+        new_group.version += len(new_rules) + bool(group.rules_to_delete)
         return new_group
 
     @filter_string

--- a/caracara/modules/custom_ioa/rules.py
+++ b/caracara/modules/custom_ioa/rules.py
@@ -262,7 +262,7 @@ class IoaRuleGroup:
         return {
             "comment": comment,
             "rule_updates": [rule.dump_update(group=self) for rule in self.rules],
-            "rulegroup_version": self.version + 1,
+            "rulegroup_version": self.version,
             "rulegroup_id": self.id_,
         }
 

--- a/tests/unit_tests/test_custom_ioas.py
+++ b/tests/unit_tests/test_custom_ioas.py
@@ -2,7 +2,7 @@
 
 import copy
 from typing import List
-from unittest.mock import DEFAULT, MagicMock
+from unittest.mock import MagicMock
 
 import falconpy
 import pytest
@@ -426,11 +426,6 @@ def test_delete_rule_groups_using_groups(client: Client, custom_ioa_api: falconp
     )
 
 
-def test_update_rule_groups_no_changes(client: Client, custom_ioa_api: falconpy.CustomIOA):
-    """Tests `CustomIoaApiModule.update_rule_group` when no changes are made"""
-
-
-
 def test_update_rule_groups_no_rules(client: Client, custom_ioa_api: falconpy.CustomIOA):
     """Tests `CustomIoaApiModule.update_rule_groups` when the group has no rules"""
     # Setup
@@ -641,8 +636,10 @@ def test_update_rule_groups_with_rule_changes(
 
     def mock_delete_rule(rule_group_id, ids, comment):
         assert raw_group["id"] == rule_group_id
+        assert ids
+        assert comment
         raw_group["version"] += 1
-        return DEFAULT
+        return {"body": {}}
 
     custom_ioa_api.delete_rules.side_effect = mock_delete_rule
 

--- a/tests/unit_tests/test_custom_ioas.py
+++ b/tests/unit_tests/test_custom_ioas.py
@@ -575,13 +575,14 @@ def test_update_rule_groups_with_rule_changes(
         raw_group["description"] = body["description"]
         raw_group["enabled"] = body["enabled"]
         raw_group["comment"] = body["comment"]
+        raw_group["version"] += 1
         return {"body": {"resources": [raw_group]}}
 
     custom_ioa_api.update_rule_group.side_effect = mock_update_rule_group
 
     def mock_update_rules(body):
         assert body["rulegroup_id"] == raw_group["id"]
-        assert body["rulegroup_version"] == raw_group["version"] + 1
+        assert body["rulegroup_version"] == raw_group["version"]
         raw_group["version"] = body["rulegroup_version"]
         for raw_rule_update in body["rule_updates"]:
             matching_rules = [
@@ -647,8 +648,8 @@ def test_update_rule_groups_with_rule_changes(
     # Assert falconpy called correctly
     # This consists of
     # - A rule group update
-    # - A rule deletion
     # - A rule update
+    # - A rule deletion
     # - A rule creation
     custom_ioa_api.update_rule_group.assert_called_once_with(
         body={
@@ -659,11 +660,6 @@ def test_update_rule_groups_with_rule_changes(
             "rulegroup_version": 1,
             "comment": "test update comment",
         }
-    )
-    custom_ioa_api.delete_rules.assert_called_once_with(
-        rule_group_id="test_group_01",
-        ids=["test_rule_01"],
-        comment="test update comment",
     )
     custom_ioa_api.update_rules.assert_called_once_with(
         body={
@@ -695,5 +691,10 @@ def test_update_rule_groups_with_rule_changes(
             "comment": "test update comment",
         }
     )
+    custom_ioa_api.delete_rules.assert_called_once_with(
+        rule_group_id="test_group_01",
+        ids=["test_rule_01"],
+        comment="test update comment",
+    )
     # Assert new group is as expected
-    assert new_group.version == group.version + 1
+    assert new_group.version == group.version + 4


### PR DESCRIPTION
# Fixes handling of Custom IOA Rule Group Versioning

- [ ] Enhancement
- [ ] Major feature update
- [X] Bug fixes
- [ ] Breaking change
- [X] Updated unit tests
- [ ] Documentation

## Bandit analysis
```shell
(caracara-py3.11) redacted@redacted caracara-fork % bandit -r caracara
[main]	INFO	profile include tests: None
[main]	INFO	profile exclude tests: None
[main]	INFO	cli include tests: None
[main]	INFO	cli exclude tests: None
[main]	INFO	running on Python 3.11.9
[manager]	WARNING	Test in comment: The is not a test name or id, ignoring
[manager]	WARNING	Test in comment: password is not a test name or id, ignoring
[manager]	WARNING	Test in comment: infected is not a test name or id, ignoring
[manager]	WARNING	Test in comment: is is not a test name or id, ignoring
[manager]	WARNING	Test in comment: generic is not a test name or id, ignoring
[manager]	WARNING	Test in comment: and is not a test name or id, ignoring
[manager]	WARNING	Test in comment: always is not a test name or id, ignoring
[manager]	WARNING	Test in comment: the is not a test name or id, ignoring
[manager]	WARNING	Test in comment: same is not a test name or id, ignoring
Run started:2024-10-18 10:21:19.988242

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 5522
	Total lines skipped (#nosec): 1

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
```
```shell
(caracara-py3.11) redacted@redacted tests % bandit -r . --skip=B101
[main]	INFO	Found project level .bandit file: ./.bandit
[utils]	WARNING	Unable to parse config file ./.bandit or missing [bandit] section
[main]	INFO	profile include tests: None
[main]	INFO	profile exclude tests: None
[main]	INFO	cli include tests: None
[main]	INFO	cli exclude tests: B101
[main]	INFO	running on Python 3.11.9
Run started:2024-10-18 10:20:41.486862

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 1446
	Total lines skipped (#nosec): 0

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
Files skipped (0):
```

## Added features and functionality

Fixed Issue #212.

## Issues resolved

- Fixes #212. This is achieved by keeping track of rule group versioning changes by rule CRUD operations

## Other
- Updated the relevant unit test
- The function `_create_update_delete_rules` was changed to `_update_create_delete_rules` after adjusting the order of operations within the function. 
