### PR TITLE
Fixes rule group addition in IoaRuleGroup._update_create_delete

### DIFF
--- a/caracara/modules/custom_ioa/custom_ioa.py
+++ b/caracara/modules/custom_ioa/custom_ioa.py
@@ -211,7 +211,7 @@ class CustomIoaApiModule(FalconApiModule):
         new_group.rules = list(
             chain(
                 (rule for rule in group.rules if rule.exists_in_cloud()),
-                (new_rule for rule in new_rules),
+                (new_rule for new_rule in new_rules),
             )
         )
 

--- a/tests/unit_tests/test_custom_ioas.py
+++ b/tests/unit_tests/test_custom_ioas.py
@@ -710,8 +710,10 @@ def test_update_rule_groups_with_rule_changes(
     assert new_group.version == group.version + 4
 
 
-def test_update_rule_group_with_new_rules(client: Client, custom_ioa_api: falconpy.CustomIOA, simple_rule_type: RuleType):
-    """"""
+def test_update_rule_group_with_new_rules(
+    client: Client, custom_ioa_api: falconpy.CustomIOA, simple_rule_type: RuleType
+):
+    """Tests `CustomIoaApiModule.update_rule_groups` when the group a rule to create."""
     raw_group = {  # Acts as a store for the API
         "customer_id": "test_customer",
         "id": "test_group_01",
@@ -822,6 +824,7 @@ def test_update_rule_group_with_new_rules(client: Client, custom_ioa_api: falcon
 
         raw_group["rules"].append(new_rule)
         return {"body": {"resources": [new_rule]}}
+
     custom_ioa_api.create_rule.side_effect = mock_create_rule
 
     custom_ioa_api.query_rule_types.side_effect = create_mock_query_resources(
@@ -832,7 +835,7 @@ def test_update_rule_group_with_new_rules(client: Client, custom_ioa_api: falcon
     )
 
     new_group = client.custom_ioas.update_rule_group(group, comment="test update comment")
-    
+
     custom_ioa_api.create_rule.assert_called_once_with(
         body={
             "name": "test rule 3",


### PR DESCRIPTION
# Fixes rule group addition in IoaRuleGroup._update_create_delete

- [ ] Enhancement
- [ ] Major feature update
- [X] Bug fixes
- [ ] Breaking change
- [X] Updated unit tests
- [ ] Documentation

## Bandit analysis

```shell
(caracara-py3.11) redacted@redacted tests % bandit -r . -s B101
[main]	INFO	Found project level .bandit file: ./.bandit
[utils]	WARNING	Unable to parse config file ./.bandit or missing [bandit] section
[main]	INFO	profile include tests: None
[main]	INFO	profile exclude tests: None
[main]	INFO	cli include tests: None
[main]	INFO	cli exclude tests: B101
[main]	INFO	running on Python 3.11.9
Run started:2024-10-25 11:47:03.460315

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 1586
	Total lines skipped (#nosec): 0

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
Files skipped (0):
```

## Added features and functionality

## Issues resolved

- Fixes a bug in rule creation for an IoaRuleGroup which results in newly created rules not being returned back after updating a rule group

## Other

- Added a unit test to cover this case. Unfortunately required a fair bit of code duplication with the way to tests are structured right now.
