### PR TITLE
Fixes attribute errors in the Custom IOA module

### DIFF
--- a/caracara/modules/custom_ioa/rules.py
+++ b/caracara/modules/custom_ioa/rules.py
@@ -312,9 +312,8 @@ class CustomIoaRule:
     # This field should exist if this object has been added to a group
     group: IoaRuleGroup
 
-    # All these fields should exist if `exists_in_cloud()` returns True, with the exception of
-    # instance_id which should exist and initialised to `None` if this object does not exist in the
-    # cloud
+    # The fields below will only be populated if `exists_in_cloud()` returns `True`,
+    # otherwise they will be `None`
     instance_id: str
     action_label: str
     comment: str
@@ -610,6 +609,8 @@ class CustomIoaRule:
 
         This object model is defined in the CrowdStrike API Swagger document.
         """
+        if not self.exists_in_cloud():
+            raise ValueError("This group does not exist in the cloud!")
         return {
             "customer_id": self.customer_id,
             "instance_id": self.instance_id,

--- a/caracara/modules/custom_ioa/rules.py
+++ b/caracara/modules/custom_ioa/rules.py
@@ -23,9 +23,7 @@ class IoaRuleGroup:
     rules_to_delete: List[CustomIoaRule]
     group: IoaRuleGroup
 
-    # The fields below will only be populated if `exists_in_cloud()` returns `True`, with the
-    # exception of `id` which should be initialised to `None` if this object does not exist on the
-    # cloud
+    # The fields below will only be populated if `exists_in_cloud()` returns `True`, otherwise they will be `None`
     id_: str
     comment: str
     committed_on: datetime
@@ -60,7 +58,19 @@ class IoaRuleGroup:
         self.rules = []
         self.rules_to_delete = []
         self.group = None
+
         self.id_ = None
+        self.comment = None
+        self.committed_on = None
+        self.created_by = None
+        self.created_on = None
+        self.customer_id = None
+        self.deleted = None
+        self.enabled = None
+        self.modified_by = None
+        self.modified_on = None
+        self.rule_ids = None
+        self.version = None
 
     def __repr__(self):
         """Return an unambiguous string representation of the IOA and its ID, platform and name."""
@@ -359,6 +369,23 @@ class CustomIoaRule:
         for field_type in rule_type.fields:
             field = field_type.to_concrete_field()
             self.fields[(field["name"], field["type"])] = field
+
+        self.instance_id = None
+        self.action_label = None
+        self.comment = None
+        self.committed_on = None
+        self.created_by = None
+        self.created_on = None
+        self.customer_id = None
+        self.deleted = None
+        self.disposition_id = None
+        self.enabled = None
+        self.instance_version = None
+        self.magic_cookie = None
+        self.modified_by = None
+        self.modified_on = None
+        self.version_ids = None
+        self.pattern_id = None
 
     def __repr__(self):
         """Return an unambiguous string representation of the CustomIoaRule and its properties.

--- a/caracara/modules/custom_ioa/rules.py
+++ b/caracara/modules/custom_ioa/rules.py
@@ -23,7 +23,8 @@ class IoaRuleGroup:
     rules_to_delete: List[CustomIoaRule]
     group: IoaRuleGroup
 
-    # The fields below will only be populated if `exists_in_cloud()` returns `True`, otherwise they will be `None`
+    # The fields below will only be populated if `exists_in_cloud()` returns `True`,
+    # otherwise they will be `None`
     id_: str
     comment: str
     committed_on: datetime

--- a/caracara/modules/custom_ioa/rules.py
+++ b/caracara/modules/custom_ioa/rules.py
@@ -364,7 +364,6 @@ class CustomIoaRule:
         self.severity = severity
         self.rule_type = rule_type
         self.group = None
-        self.instance_id = None
 
         self.fields = {}
         for field_type in rule_type.fields:

--- a/tests/unit_tests/test_custom_ioas.py
+++ b/tests/unit_tests/test_custom_ioas.py
@@ -854,13 +854,24 @@ def test_update_rule_group_with_new_rules(
 def test_ioa_rule_group_repr():
     """Tests the `__repr__` function of an IoaRuleGroup."""
     irg = IoaRuleGroup("name", "desc", "platform")
-    assert str(irg) == "<IoaRuleGroup(id_=None, version=None, platform='platform', name='name', ...)>"
+    assert (
+        str(irg) == "<IoaRuleGroup(id_=None, version=None, platform='platform', name='name', ...)>"
+    )
+
 
 def test_ioa_rule_repr(simple_rule_type: RuleType):
     """Tests the `__repr__` function of an CustomIoaRule."""
     ir = CustomIoaRule("name", "desc", "informational", simple_rule_type)
-    assert str(ir) == "<CustomIoaRule(group=None, instance_id=None, instance_version=None name='name', ruletype=<RuleType(id_='test_rule_type_simple', name='SimpleType', platform='windows', ...)>, ...)>"
+    assert str(ir) == (
+        "<CustomIoaRule(group=None, instance_id=None, instance_version=None name='name', "
+        "ruletype=<RuleType(id_='test_rule_type_simple', "
+        "name='SimpleType', platform='windows', ...)>, ...)>"
+    )
+
 
 def test_rule_type_repr(simple_rule_type: RuleType):
     """Tests the `__repr__` function of an RuleType."""
-    assert str(simple_rule_type) ==  "<RuleType(id_='test_rule_type_simple', name='SimpleType', platform='windows', ...)>"
+    assert (
+        str(simple_rule_type)
+        == "<RuleType(id_='test_rule_type_simple', name='SimpleType', platform='windows', ...)>"
+    )

--- a/tests/unit_tests/test_custom_ioas.py
+++ b/tests/unit_tests/test_custom_ioas.py
@@ -849,3 +849,18 @@ def test_update_rule_group_with_new_rules(
         }
     )
     assert len([rule for rule in new_group.rules if rule.exists_in_cloud()]) == len(group.rules)
+
+
+def test_ioa_rule_group_repr():
+    """Tests the `__repr__` function of an IoaRuleGroup."""
+    irg = IoaRuleGroup("name", "desc", "platform")
+    assert str(irg) == "<IoaRuleGroup(id_=None, version=None, platform='platform', name='name', ...)>"
+
+def test_ioa_rule_repr(simple_rule_type: RuleType):
+    """Tests the `__repr__` function of an CustomIoaRule."""
+    ir = CustomIoaRule("name", "desc", "informational", simple_rule_type)
+    assert str(ir) == "<CustomIoaRule(group=None, instance_id=None, instance_version=None name='name', ruletype=<RuleType(id_='test_rule_type_simple', name='SimpleType', platform='windows', ...)>, ...)>"
+
+def test_rule_type_repr(simple_rule_type: RuleType):
+    """Tests the `__repr__` function of an RuleType."""
+    assert str(simple_rule_type) ==  "<RuleType(id_='test_rule_type_simple', name='SimpleType', platform='windows', ...)>"


### PR DESCRIPTION
# Fixes attribute errors in the Custom IOA module

- [ ] Enhancement
- [ ] Major feature update
- [X] Bug fixes
- [ ] Breaking change
- [X] Updated unit tests
- [ ] Documentation

## Added features and functionality

Fixed a bug causing AttributeErrors when accessing cloud fields of `IoaRuleGroup` and `CustomIoaRule` objects.

## Issues resolved

- Bug fix: Fixes #213 by properly initializing all attributes of `IoaRuleGroup` and `CustomIoaRule` objects during `__init__`

## Notes

This does not attempt to separate local instances of the objects from clouded instances.
While this prevents a call to e.g. `rule.deleted` from raising an exception, the property is not meaningful on local (to be created in the cloud) objects. I think it's worth considering whether keeping the current behaviour of throwing an error in these cases would be preferable. If so, `__repr__` can be fixed by changing its functionality in the case of local objects. 

