### PR TITLE
Add FalconPy native logging support

### DIFF
--- a/caracara/client.py
+++ b/caracara/client.py
@@ -60,6 +60,9 @@ class Client:
         proxy: str = None,
         user_agent: str = None,
         verbose: bool = False,
+        debug: bool = False,
+        debug_record_count: int = None,
+        sanitize_log: bool = True,
         falconpy_authobject: OAuth2 = None,
     ):
         """Configure a Caracara Falcon API Client object."""
@@ -110,6 +113,9 @@ class Client:
                 "user_agent": user_agent,
                 "ssl_verify": ssl_verify,
                 "timeout": timeout,
+                "debug": debug,
+                "debug_record_count": debug_record_count,
+                "sanitize_log": sanitize_log,
             }
 
             self.logger.info(

--- a/examples/config.example.yml
+++ b/examples/config.example.yml
@@ -4,6 +4,12 @@ profiles:
       client_id: clientid123456
       client_secret: clientsecret123456
       cloud_name: auto
+      # Enable FalconPy native debugging by setting to True
+      debug: False
+      # Number of records to return in a debug
+      debug_record_count: 100
+      # Do not disable log sanitization in production environments
+      sanitize_log: True
     logging:
       level: debug
     examples:


### PR DESCRIPTION
# Add FalconPy native logging
This update enables support for FalconPy native logging.

- [x] Enhancement

## Bandit analysis

```shell
[main]	INFO	running on Python 3.13.0

Run started:2024-11-01 07:57:30.838541

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 5563
	Total lines skipped (#nosec): 1

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
Files skipped (0):
```

## Added features and functionality

Adds support for FalconPy debugging-related constructor keywords provided by the OAuth2 object.
- New keyword arguments: 
    - `debug`
    - `debug_record_count`
    - `sanitize_log`
* `client.py`

Demonstrates how to add these values to a configuration profile stored within `config.yml`.
* `examples/config.example.yml`
