### PR TITLE
DRAFT: Fix missing section header in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,9 @@ disable = [
     # (from Falcon) by definition. Therefore, we have switched this rule off globally.
     "too-many-public-methods",
 ]
-max-positional-arguments=10
 
+[tool.pylint.DESIGN]
+max-positional-arguments = 10
 
 [tool.poetry.scripts]
 # Hosts


### PR DESCRIPTION
# Fix missing section header in pyproject.toml

- [ ] Enhancement
- [ ] Major feature update
- [X] Bug fixes
- [ ] Breaking change
- [ ] Updated unit tests
- [ ] Documentation

> Check the values above that match your PR and remove the remaining.

## Added features and functionality

If your PR adds features or functionality, what should be included in the next release notes?

## Issues resolved

- Fixes a unrecognized option due to missing section in pyproject.toml

## Other

```python3
Run poetry run pylint caracara/
************* Module /home/runner/work/caracara/caracara/pyproject.toml
pyproject.toml:1:0: E0015: Unrecognized option found: max-positional-arguments (unrecognized-option)
```
